### PR TITLE
fix: BodyLoader: A imagem com loader não aparece na tela, apenas o blur

### DIFF
--- a/components/BodyLoader/index.tsx
+++ b/components/BodyLoader/index.tsx
@@ -3,6 +3,7 @@
 import Image from "next/image"
 import Logo from 'public/images/white-pokeball.svg'
 import { BodyOverlay } from 'components/BodyOverlay'
+import { createPortal } from "react-dom"
 
 
 
@@ -11,10 +12,28 @@ export const BodyLoader = () => {
 
   return (
     <>
-      <div className='bg-primary-500 p-4 rounded-full'>
-        <Image src={Logo} width={80} height={80} alt="" className='animate-pulse duration-75 w-20 h-20' />
-      </div>
-      <BodyOverlay />
+      {
+        createPortal(
+          (
+            <>
+              <div
+                className='
+                  fixed 
+                  top-1/2 left-1/2 
+                  -translate-x-1/2 -translate-y-1/2 
+                  bg-primary-500 
+                  p-4 
+                  rounded-full 
+                  z-40
+                '
+              >
+                <Image src={Logo} width={80} height={80} alt="" className='animate-pulse duration-75 w-20 h-20' />
+              </div>
+              <BodyOverlay />
+            </>
+          ), document.body
+        )
+      }
     </>
 
   )


### PR DESCRIPTION

Precisei passar o componente novamente para o createPortal (que havia sido removido quando o componente de blur foi criado) e setar o componente para fixed novamente.

Isso para que consigamos garantir que, independente do contexto em que for chamado, ele sempre terá o mesmo comportamento.